### PR TITLE
Add Support for Sending Multicast Commands through ZWave JS Bridge

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/action/ZwaveJSActions.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/action/ZwaveJSActions.java
@@ -15,6 +15,7 @@ package org.openhab.binding.zwavejs.internal.action;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.zwavejs.internal.handler.ZwaveJSBridgeHandler;
+import org.openhab.core.automation.annotation.ActionInput;
 import org.openhab.core.automation.annotation.RuleAction;
 import org.openhab.core.thing.binding.ThingActions;
 import org.openhab.core.thing.binding.ThingActionsScope;
@@ -59,6 +60,25 @@ public class ZwaveJSActions implements ThingActions {
 
     public static void startExclusion(ThingActions actions) {
         ((ZwaveJSActions) actions).startExclusion();
+    }
+
+    @RuleAction(label = "send multicast command", description = "Send command to multiple nodes")
+    public void sendMulticastCommand(
+            @ActionInput(name = "nodeIDs", label = "node IDs", description = "Comma separated list of Z-Wave node IDs") String nodeIDs,
+            @ActionInput(name = "commandClass", label = "command class", description = "Z-Wave command class") Integer commandClass,
+            @ActionInput(name = "endpoint", label = "endpoint", description = "Z-Wave endpoint") Integer endpoint,
+            @ActionInput(name = "property", label = "property", description = "Z-Wave write property") String property,
+            @ActionInput(name = "value", label = "value", description = "Value to write") String value) {
+        ZwaveJSBridgeHandler localHandler = handler;
+        if (localHandler != null) {
+            logger.debug("Multicast action issued");
+            localHandler.sendMulticastCommand(nodeIDs, commandClass, endpoint, property, value);
+        }
+    }
+
+    public static void sendMulticastCommand(ThingActions actions, String nodeIDs, Integer commandClass,
+            Integer endpoint, String property, String value) {
+        ((ZwaveJSActions) actions).sendMulticastCommand(nodeIDs, commandClass, endpoint, property, value);
     }
 
     @Override

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/dto/commands/MulticastSetValueCommand.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/dto/commands/MulticastSetValueCommand.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2010-2024 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.zwavejs.internal.api.dto.commands;
+
+import org.openhab.binding.zwavejs.internal.api.dto.ValueId;
+
+/**
+ * @author Garrett Scoville - Initial contribution
+ */
+public class MulticastSetValueCommand extends BaseCommand {
+    public int[] nodeIDs;
+    public ValueId valueId;
+    public Object value;
+
+    public MulticastSetValueCommand(int[] nodeIDs, Object commandClass, Integer endpoint, String property,
+            Object value) {
+        command = "multicast_group.set_value";
+        this.nodeIDs = nodeIDs;
+        this.value = value;
+
+        this.valueId = new ValueId();
+        this.valueId.commandClass = commandClass;
+        this.valueId.endpoint = endpoint;
+        this.valueId.property = property;
+    }
+}

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.zwavejs.internal.handler;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,6 +33,7 @@ import org.openhab.binding.zwavejs.internal.api.dto.Status;
 import org.openhab.binding.zwavejs.internal.api.dto.commands.BaseCommand;
 import org.openhab.binding.zwavejs.internal.api.dto.commands.ControllerExclusionCommand;
 import org.openhab.binding.zwavejs.internal.api.dto.commands.ControllerInclusionCommand;
+import org.openhab.binding.zwavejs.internal.api.dto.commands.MulticastSetValueCommand;
 import org.openhab.binding.zwavejs.internal.api.dto.commands.ServerListeningCommand;
 import org.openhab.binding.zwavejs.internal.api.dto.messages.BaseMessage;
 import org.openhab.binding.zwavejs.internal.api.dto.messages.EventMessage;
@@ -178,7 +180,7 @@ public class ZwaveJSBridgeHandler extends BaseBridgeHandler implements ZwaveEven
 
     /**
      * Initiates a full refresh of all data from the remote service.
-     * 
+     *
      */
     public void getFullState() {
         if (getThing().getStatus().equals(ThingStatus.ONLINE)) {
@@ -258,5 +260,23 @@ public class ZwaveJSBridgeHandler extends BaseBridgeHandler implements ZwaveEven
 
     public void startExclusion() {
         sendCommand(new ControllerExclusionCommand());
+    }
+
+    public void sendMulticastCommand(String nodeIDs, Integer commandClass, Integer endpoint, String property,
+            String value) {
+        sendCommand(new MulticastSetValueCommand(parseNodeIDs(nodeIDs), commandClass, endpoint, property,
+                convertValueType(value)));
+    }
+
+    private static int[] parseNodeIDs(String nodeIDs) {
+        return Arrays.stream(nodeIDs.split(",")).map(String::trim).mapToInt(Integer::parseInt).toArray();
+    }
+
+    private static Object convertValueType(String value) {
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException e) {
+            return value;
+        }
     }
 }


### PR DESCRIPTION
# Title
Add Support for Sending Multicast Commands through Z-Wave JS Bridge

# Description
Z-Wave supports multicast packets and so does [Z-Wave JS](https://zwave-js.github.io/zwave-js/#/api/controller?id=controlling-multiple-nodes-at-once-multicast-broadcast).  Multicast allows you send a single command to multiple nodes at a time, reducing the waterfall effect.  This PR adds an action to the ZWave JS gateway thing for sending multicast commands.

# Testing
I've tested this myself and am currently using it in my own home to control groups of roller shades.  I struggled a bit to figure out how something like this fits into the OpenHAB constructs (item, thing, channel, etc) and am open to alternatives here if anyone has any ideas.  

For those interested, my setup is currently: an item with no linked channels but has metadata containing node ids -> rule that triggers on changes to the item -> script below
```
var item = items.getItem(event.itemName);
var nodeIds = item.getMetadata('node_ids').value;
var value = item.state;

if (value == 100) {
  value = 99;
}

actions.get('zwavejs', 'zwavejs:gateway:4124922451').sendMulticastCommand(nodeIds, 38, 0, 'targetValue', value.toString());
```
