### PR TITLE
Fix bug in reconnect logic

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/ZWaveJSClient.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/ZWaveJSClient.java
@@ -57,22 +57,22 @@ import com.google.gson.typeadapters.RuntimeTypeAdapterFactory;
  * The {@code ZWaveJSClient} class is responsible for managing the WebSocket connection
  * to the Z-Wave JS Webservice. It implements the {@link WebSocketListener} interface to
  * handle WebSocket events such as connection, disconnection, and message reception.
- * 
+ *
  * <p>
  * This class provides methods to start and stop the WebSocket connection, as well as
  * to add and remove event listeners for Z-Wave events. It also includes functionality
  * to send commands to the Z-Wave JS server.
- * 
+ *
  * <p>
  * Thread Safety: This class is thread-safe. It uses a {@link CopyOnWriteArraySet} for
  * managing event listeners and ensures that the WebSocket session is accessed in a
  * thread-safe manner.
- * 
+ *
  * @see WebSocketListener
  * @see WebSocketClient
  * @see BaseMessage
  * @see BaseCommand
- * 
+ *
  * @author Leo Siepel - Initial contribution
  */
 @NonNullByDefault
@@ -188,7 +188,7 @@ public class ZWaveJSClient implements WebSocketListener {
             return;
         }
         logger.info("Scheduling reconnect to Z-Wave JS Webservice every {} minutes", RECONNECT_INTERVAL_MINUTES);
-        reconnectFuture = scheduler.scheduleAtFixedRate(() -> {
+        this.reconnectFuture = scheduler.scheduleAtFixedRate(() -> {
             try {
                 start(this.uri);
                 ScheduledFuture<?> future = this.reconnectFuture;


### PR DESCRIPTION
# Title
Fix bug in reconnect logic

# Description
There is a minor bug in the current reconnection logic where multiple reconnection attempts will be made.  The current implementation was assigning the future to a local variable instead of an instance variable.

# Testing

I've encountered this log on my setup:
```
...
2025-04-29 11:14:37.255 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.256 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.256 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.256 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.256 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.256 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.257 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.257 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.258 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.258 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.258 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
2025-04-29 11:14:37.259 [INFO ] [g.zwavejs.internal.api.ZWaveJSClient] - Scheduling reconnect to Z-Wave JS Webservice every 2 minutes
...
```

And it continues.  This brings down Z-Wave JS as it's flooding the connection.