### PR TITLE
Propagate Node Status (Alive/Dead) from Z-Wave JS to Thing Status in OpenHAB

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSBridgeHandler.java
@@ -129,6 +129,16 @@ public class ZwaveJSBridgeHandler extends BaseBridgeHandler implements ZwaveEven
                 if (nodeListener != null) {
                     nodeListener.onNodeStateChanged(result.event);
                 }
+            } else if ("alive".equals(result.event.event)) {
+                final ZwaveNodeListener nodeListener = nodeListeners.get(result.event.nodeId);
+                if (nodeListener != null) {
+                    nodeListener.onNodeAlive(result.event);
+                }
+            } else if ("dead".equals(result.event.event)) {
+                final ZwaveNodeListener nodeListener = nodeListeners.get(result.event.nodeId);
+                if (nodeListener != null) {
+                    nodeListener.onNodeDead(result.event);
+                }
             }
         }
     }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveJSNodeHandler.java
@@ -325,6 +325,18 @@ public class ZwaveJSNodeHandler extends BaseThingHandler implements ZwaveNodeLis
     }
 
     @Override
+    public void onNodeDead(Event event) {
+        logger.trace("Node {}. Dead", config.id);
+        updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Z-Wave JS reported this node dead");
+    }
+
+    @Override
+    public void onNodeAlive(Event event) {
+        logger.trace("Node {}. Alive", config.id);
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
     public Integer getId() {
         return this.config.id;
     }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveNodeListener.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/handler/ZwaveNodeListener.java
@@ -20,7 +20,7 @@ import org.openhab.binding.zwavejs.internal.api.dto.Node;
  * The {@link ZwaveNodeListener} interface defines the methods that must be implemented by any class
  * that wishes to receive notifications about changes to the state of a node, the addition
  * or removal of nodes, and other node-related events.
- * 
+ *
  * @author Leo Siepel - Initial contribution
  */
 @NonNullByDefault
@@ -40,6 +40,20 @@ public interface ZwaveNodeListener {
      * @return true if the state change was handled successfully, false otherwise
      */
     boolean onNodeStateChanged(Event event);
+
+    /**
+     * This method is called when the node is dead
+     *
+     * @param event the event that contains information about the status change
+     */
+    void onNodeDead(Event event);
+
+    /**
+     * This method is called when the node is alive
+     *
+     * @param event the event that contains information about the status change
+     */
+    void onNodeAlive(Event event);
 
     /**
      * This method is called when a node is removed from the Z-Wave network.


### PR DESCRIPTION
# Title
Propagate Node Status (Alive/Dead) from Z-Wave JS to Thing Status in OpenHAB

# Description
Z-Wave JS sends alive / dead events when a node's status has changed.  Prior to this PR, this binding was ignoring those events.  This led to the thing status in OpenHAB getting out of sync with what was reported in Z-Wave JS.  

# Testing
I've tested this in my home by bring devices on and offline and seeing the status update in OpenHAB