### PR TITLE
Don't overwrite a write property with its read property

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
@@ -217,10 +217,11 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
         Channel existingChannel = channels.get(channelUID.getId());
         if (existingChannel != null) {
             Configuration existingChannelConfiguration = existingChannel.getConfiguration();
-            if (ChannelMetadata.isSameReadWriteChannel(existingChannelConfiguration, newChannelConfiguration)) {
+            if (ChannelMetadata.isSameReadWriteChannel(existingChannelConfiguration, newChannelConfiguration)
+                    && details.writable) {
                 ChannelTypeUID newChannelTypeUID = generateChannelTypeUID(details);
                 ChannelBuilder builder = ChannelBuilder.create(existingChannel)
-                        .withConfiguration(details.writable ? newChannelConfiguration : existingChannelConfiguration);
+                        .withConfiguration(newChannelConfiguration);
 
                 if (!newChannelTypeUID.equals(existingChannel.getChannelTypeUID())) {
                     ChannelType newChannelType = getOrGenerate(newChannelTypeUID, details);


### PR DESCRIPTION
This resolves the issue described at https://github.com/openhab/openhab-addons/pull/18694#issuecomment-2952761337. I haven't studied it in depth, though - one test fails. And I had to delete and re-create my thing for it to change to a Dimmer property. Another nice thing is that the channel label will consistently be "Target Value" instead of seemingly randomly being "Target Value" or "Current Value".