### PR TITLE
fix writing to properties that don't have a name

### DIFF
--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/BindingConstants.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/BindingConstants.java
@@ -49,7 +49,8 @@ public class BindingConstants {
     public static final String CONFIG_CHANNEL_PROPERTY_KEY_STR = "propertyKeyStr";
     public static final String CONFIG_CHANNEL_PROPERTY_KEY_INT = "propertyKeyInt";
     public static final String CONFIG_CHANNEL_READ_PROPERTY = "readProperty";
-    public static final String CONFIG_CHANNEL_WRITE_PROPERTY = "writeProperty";
+    public static final String CONFIG_CHANNEL_WRITE_PROPERTY_STR = "writePropertyStr";
+    public static final String CONFIG_CHANNEL_WRITE_PROPERTY_INT = "writePropertyInt";
     public static final String CONFIG_CHANNEL_INVERTED = "inverted";
     public static final String CONFIG_CHANNEL_FACTOR = "factor";
 

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/dto/ValueId.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/dto/ValueId.java
@@ -18,6 +18,6 @@ package org.openhab.binding.zwavejs.internal.api.dto;
 public class ValueId {
     public Object commandClass;
     public Integer endpoint;
-    public String property;
+    public Object property;
     public Object propertyKey;
 }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/dto/commands/NodeSetValueCommand.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/api/dto/commands/NodeSetValueCommand.java
@@ -32,6 +32,6 @@ public class NodeSetValueCommand extends BaseCommand {
         this.valueId.commandClass = config.commandClassId;
         this.valueId.endpoint = config.endpoint;
         this.valueId.propertyKey = config.propertyKeyInt != null ? config.propertyKeyInt : config.propertyKeyStr;
-        this.valueId.property = config.writeProperty;
+        this.valueId.property = config.writePropertyInt != null ? config.writePropertyInt : config.writePropertyStr;
     }
 }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/config/ZwaveJSChannelConfiguration.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/config/ZwaveJSChannelConfiguration.java
@@ -30,7 +30,8 @@ public class ZwaveJSChannelConfiguration {
     public @Nullable Integer propertyKeyInt;
     public @Nullable String propertyKeyStr;
     public @Nullable String readProperty;
-    public @Nullable String writeProperty;
+    public @Nullable Integer writePropertyInt;
+    public @Nullable String writePropertyStr;
     public boolean inverted = false;
     public double factor = 1.0;
 }

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/ChannelMetadata.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/conversion/ChannelMetadata.java
@@ -96,11 +96,14 @@ public class ChannelMetadata extends BaseMetadata {
         ZwaveJSChannelConfiguration cA = configA.as(ZwaveJSChannelConfiguration.class);
         ZwaveJSChannelConfiguration cB = configB.as(ZwaveJSChannelConfiguration.class);
 
+        Object writePropertyA = cA.writePropertyInt != null ? cA.writePropertyInt : cA.writePropertyStr;
+        Object writePropertyB = cB.writePropertyInt != null ? cB.writePropertyInt : cB.writePropertyStr;
+
         return cA.endpoint == cB.endpoint //
                 && cA.commandClassId == cB.commandClassId //
                 && compare(cA.propertyKeyInt, cB.propertyKeyInt) //
                 && compare(cA.propertyKeyStr, cB.propertyKeyStr) //
-                && !compare(cA.writeProperty, cB.writeProperty); //
+                && !compare(writePropertyA, writePropertyB); //
     }
 
     public boolean isIgnoredCommandClass(@Nullable String commandClassName) {

--- a/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
+++ b/bundles/org.openhab.binding.zwavejs/src/main/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorImpl.java
@@ -253,12 +253,7 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
         config.put(BindingConstants.CONFIG_CHANNEL_FACTOR, details.factor);
         config.put(BindingConstants.CONFIG_CHANNEL_INVERTED, false);
 
-        if (details.writeProperty != null) {
-            config.put(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY, String.valueOf(details.writeProperty));
-        }
-        if (details.readProperty != null) {
-            config.put(BindingConstants.CONFIG_CHANNEL_READ_PROPERTY, String.valueOf(details.readProperty));
-        }
+        updateReadWriteProperties(config, details);
         return config;
     }
 
@@ -266,8 +261,10 @@ public class ZwaveJSTypeGeneratorImpl implements ZwaveJSTypeGenerator {
      * Updates the read/write properties of an existing channel configuration.
      */
     private void updateReadWriteProperties(Configuration config, ChannelMetadata details) {
-        if (details.writeProperty != null) {
-            config.put(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY, String.valueOf(details.writeProperty));
+        if (details.writeProperty instanceof Number writePropertyInteger) {
+            config.put(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY_INT, writePropertyInteger);
+        } else if (details.writeProperty instanceof String writePropertyString) {
+            config.put(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY_STR, writePropertyString);
         }
         if (details.readProperty != null) {
             config.put(BindingConstants.CONFIG_CHANNEL_READ_PROPERTY, String.valueOf(details.readProperty));

--- a/bundles/org.openhab.binding.zwavejs/src/main/resources/OH-INF/config/channel-config.xml
+++ b/bundles/org.openhab.binding.zwavejs/src/main/resources/OH-INF/config/channel-config.xml
@@ -43,8 +43,12 @@
 			<label>Read Property</label>
 			<advanced>true</advanced>
 		</parameter>
-		<parameter name="writeProperty" type="text">
-			<label>Write Property</label>
+		<parameter name="writePropertyStr" type="text">
+			<label>Write Property Str</label>
+			<advanced>true</advanced>
+		</parameter>
+		<parameter name="writePropertyInt" type="integer">
+			<label>Write Property Int</label>
 			<advanced>true</advanced>
 		</parameter>
 	</config-description>

--- a/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorTest.java
+++ b/bundles/org.openhab.binding.zwavejs/src/test/java/org/openhab/binding/zwavejs/internal/type/ZwaveJSTypeGeneratorTest.java
@@ -145,7 +145,9 @@ public class ZwaveJSTypeGeneratorTest {
         Channel channel = getChannel("store_4.json", 7,
                 "configuration-key-s-1-associations-send-on-with-single-click-1", true);
 
-        assertEquals("24", channel.getConfiguration().get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY));
+        assertNull(channel.getConfiguration().get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY_STR));
+        assertEquals(BigDecimal.valueOf(24),
+                channel.getConfiguration().get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY_INT));
     }
 
     @Test
@@ -167,7 +169,7 @@ public class ZwaveJSTypeGeneratorTest {
         assertEquals("zwavejs:test-bridge:test-thing:multilevel-switch-value-1", channel.getUID().getAsString());
         assertEquals("Dimmer", Objects.requireNonNull(type).getItemType());
         assertEquals("EP1 Current Value", channel.getLabel());
-        assertNotNull(configuration.get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY));
+        assertNotNull(configuration.get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY_STR));
 
         StateDescription statePattern = type.getState();
         assertNotNull(statePattern);
@@ -191,7 +193,7 @@ public class ZwaveJSTypeGeneratorTest {
         assertEquals("zwavejs:test-bridge:test-thing:multilevel-switch-value", channel.getUID().getAsString());
         assertEquals("Dimmer", Objects.requireNonNull(type).getItemType());
         assertEquals("Current Value", channel.getLabel());
-        assertNotNull(configuration.get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY));
+        assertNotNull(configuration.get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY_STR));
 
         StateDescription statePattern = type.getState();
         assertNotNull(statePattern);
@@ -212,7 +214,7 @@ public class ZwaveJSTypeGeneratorTest {
         assertEquals("zwavejs:test-bridge:test-thing:color-switch-hex-color", channel.getUID().getAsString());
         assertEquals("Color", Objects.requireNonNull(type).getItemType());
         assertEquals("RGB Color", channel.getLabel());
-        assertNotNull(configuration.get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY));
+        assertNotNull(configuration.get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY_STR));
 
         StateDescription statePattern = type.getState();
         assertNotNull(statePattern);
@@ -232,14 +234,14 @@ public class ZwaveJSTypeGeneratorTest {
     public void testGenCTNode7WriteProperty() throws IOException {
         Channel channel = getChannel("store_4.json", 7, "multilevel-switch-value-1");
 
-        assertEquals("targetValue", channel.getConfiguration().get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY));
+        assertEquals("targetValue", channel.getConfiguration().get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY_STR));
     }
 
     @Test
     public void testGenCTNode25WriteProperty() throws IOException {
         Channel channel = getChannel("store_4.json", 25, "binary-switch-value-1");
 
-        assertEquals("targetValue", channel.getConfiguration().get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY));
+        assertEquals("targetValue", channel.getConfiguration().get(BindingConstants.CONFIG_CHANNEL_WRITE_PROPERTY_STR));
     }
 
     @Test


### PR DESCRIPTION
Without this, I get

```
2025-06-09 08:44:28.139 [DEBUG] [.internal.handler.ZwaveJSNodeHandler] - Node 4. Processing command 1 type DecimalType for channel zwavejs:node:4024710665:node4:configuration-enable-disable-custom-led-status-mode
2025-06-09 08:44:28.140 [DEBUG] [g.zwavejs.internal.api.ZWaveJSClient] - Sending command: NodeSetValueCommand.
2025-06-09 08:44:28.140 [DEBUG] [g.zwavejs.internal.api.ZWaveJSClient] - SEND | {"nodeId":4,"valueId":{"commandClass":112,"endpoint":0,"property":"13"},"value":1.0,"command":"node.set_value"}
2025-06-09 08:44:28.141 [DEBUG] [g.zwavejs.internal.api.ZWaveJSClient] - onWebSocketText received message type: result, success: true
2025-06-09 08:44:28.141 [TRACE] [g.zwavejs.internal.api.ZWaveJSClient] - RECV | {"type":"result","success":true,"result":{"result":{"status":5,"message":"Configuration: \"13\" is not a supported property (ZW0322)"}}}
```

Note in particular the `"property": "13"` in the `set_value` command, and the error.

With this change it goes through successfully:

```
2025-06-09 09:31:01.409 [DEBUG] [.internal.handler.ZwaveJSNodeHandler] - Node 4. Processing command 1 type DecimalType for channel zwavejs:node:4024710665:node4:configuration-enable-disable-custom-led-status-mode
2025-06-09 09:31:01.409 [DEBUG] [g.zwavejs.internal.api.ZWaveJSClient] - Sending command: NodeSetValueCommand.
2025-06-09 09:31:01.409 [DEBUG] [g.zwavejs.internal.api.ZWaveJSClient] - SEND | {"nodeId":4,"valueId":{"commandClass":112,"endpoint":0,"property":13},"value":1.0,"command":"node.set_value"}
2025-06-09 09:31:02.345 [TRACE] [g.zwavejs.internal.api.ZWaveJSClient] - Received EventMessage, type: value updated
2025-06-09 09:31:02.346 [TRACE] [g.zwavejs.internal.api.ZWaveJSClient] - RECV | {"type":"event","event":{"source":"node","event":"value updated","nodeId":4,"args":{"commandClassName":"Configuration","commandClass":112,"endpoint":0,"property":13,"newValue":1,"prevValue":1,"propertyName":"Enable / Disable Custom LED Status Mode"}}}
2025-06-09 09:31:02.346 [TRACE] [.internal.handler.ZwaveJSNodeHandler] - Node 4. State changed event
2025-06-09 09:31:02.346 [TRACE] [.internal.handler.ZwaveJSNodeHandler] - Getting the configuration for linked channel configuration-enable-disable-custom-led-status-mode
2025-06-09 09:31:02.346 [DEBUG] [g.zwavejs.internal.api.ZWaveJSClient] - Received ResultMessage type: result, success: true
2025-06-09 09:31:02.347 [DEBUG] [g.zwavejs.internal.api.ZWaveJSClient] - RECV | {"type":"result","success":true,"result":{"result":{"status":254}}}
```

(note that the config key changed for writeProperty, so you'll need to re-create your things -- or do a find replace on the jsondb ;) )