### PR TITLE
Rudimentary mDNS support

### DIFF
--- a/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/factory/ChromecastHandlerFactory.java
+++ b/bundles/org.openhab.binding.chromecast/src/main/java/org/openhab/binding/chromecast/internal/factory/ChromecastHandlerFactory.java
@@ -24,6 +24,7 @@ import org.openhab.binding.chromecast.internal.ChromecastAudioSink;
 import org.openhab.binding.chromecast.internal.handler.ChromecastHandler;
 import org.openhab.core.audio.AudioHTTPServer;
 import org.openhab.core.audio.AudioSink;
+import org.openhab.core.io.transport.mdns.MDNSClient;
 import org.openhab.core.net.HttpServiceUtil;
 import org.openhab.core.net.NetworkAddressService;
 import org.openhab.core.thing.Thing;
@@ -52,16 +53,18 @@ public class ChromecastHandlerFactory extends BaseThingHandlerFactory {
     private final Map<String, ServiceRegistration<AudioSink>> audioSinkRegistrations = new ConcurrentHashMap<>();
     private final AudioHTTPServer audioHTTPServer;
     private final NetworkAddressService networkAddressService;
+    private final MDNSClient mdnsClient;
 
     /** url (scheme+server+port) to use for playing notification sounds. */
     private @Nullable String callbackUrl;
 
     @Activate
     public ChromecastHandlerFactory(final @Reference AudioHTTPServer audioHTTPServer,
-            final @Reference NetworkAddressService networkAddressService) {
+            final @Reference NetworkAddressService networkAddressService, @Reference MDNSClient mdnsClient) {
         logger.debug("Creating new instance of ChromecastHandlerFactory");
         this.audioHTTPServer = audioHTTPServer;
         this.networkAddressService = networkAddressService;
+        this.mdnsClient = mdnsClient;
     }
 
     @Override
@@ -78,7 +81,7 @@ public class ChromecastHandlerFactory extends BaseThingHandlerFactory {
 
     @Override
     protected @Nullable ThingHandler createHandler(Thing thing) {
-        ChromecastHandler handler = new ChromecastHandler(thing);
+        ChromecastHandler handler = new ChromecastHandler(thing, mdnsClient);
         ChromecastAudioSink audioSink = new ChromecastAudioSink(handler, audioHTTPServer, createCallbackUrl());
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
@lsiepel I don't intend for this to be a final implementation, I've just added a rudimentary use of mDNS for `CastDevice` creation.

The fundamental approach is probably fine, but I think the details should be refined - especially that search for the IP address and what to do if none are found.

I haven't looked at the discovery yet, but some field must be used as "representative property" to prevent the same device being discovered multiple times. IP address probably isn't suitable here, since can can't really configure the IP addresses so that they will be dynamic/DHCP based. I think there's a "unique ID" among the mDNS details that would probably be the most suitable, and if so, creating a `CastDevice` without mDNS info might not be a good idea, since it would allow for the same device being discovered as well.

Regardless, here's the rudimentary implementation if you want it - it's at least a start.